### PR TITLE
Refactor for simplifying

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,8 +27,6 @@ jobs:
       WORDPRESS_VERSION: ${{ matrix.software-versions[2] }}
       PHP_UNIT_VERSION: ${{ matrix.software-versions[3] }}
       MYSQL_VERSION: ${{ matrix.software-versions[4] }}
-      #Since the image: futureys/ssl-certificate:2.0.2 only supports sud-domain.
-      DOMAIN_NAME: futureys.net
     runs-on: ubuntu-latest
     steps:
       - uses: docker/setup-qemu-action@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,8 +36,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - id: extract-tag
-        run: echo "DOCKER_TAG=$(echo ${GITHUB_REF#refs/tags/v})" >> $GITHUB_ENV
       - uses: docker/bake-action@v6
         with:
           push: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,6 @@ jobs:
       WORDPRESS_VERSION: ${{ matrix.software-versions[2] }}
       PHP_UNIT_VERSION: ${{ matrix.software-versions[3] }}
       MYSQL_VERSION: ${{ matrix.software-versions[4] }}
-      #Since the image: futureys/ssl-certificate:2.0.2 only supports sud-domain.
-      DOMAIN_NAME: futureys.net
     runs-on: ubuntu-latest
     steps:
       - uses: docker/setup-qemu-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,11 +40,17 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - id: extract-tag
-        run: echo "DOCKER_TAG=test" >> $GITHUB_ENV
       - uses: docker/bake-action@v6
         with:
           builder: ${{ steps.buildx.outputs.name }}
           targets: app-release
+        env:
+          DOCKER_TAG: ${{ env.WORDPRESS_VERSION }}-php${{ env.PHP_IMAGE_TAG }}
+      - uses: docker/bake-action@v6
+        with:
+          load: true
+          builder: ${{ steps.buildx.outputs.name }}
+        env:
+          DOCKER_TAG: ${{ env.WORDPRESS_VERSION }}-php${{ env.PHP_IMAGE_TAG }}
       - uses: actions/checkout@v5
       - run: docker compose -f compose.yml -f compose.test.yml run --rm phpunit-wordpress-plugin

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -4,23 +4,23 @@ services:
   # that SSL certificate isn't able to set CN, we need to create our own SSL certificate files.
   ssl_certificate:
     environment:
-      DOMAIN_NAME: ${DOMAIN_NAME?err}
-    image: futureys/ssl-certificate:2.0.2
+      DOMAIN_NAME: database
+      SUPPORT_ROOT_DOMAIN: true
+    image: futureys/ssl-certificate:2.1.1
     volumes:
       - pki:/etc/pki
-  #Since the image: futureys/ssl-certificate:2.0.2 only supports sud-domain.
-  database.futureys.net:
+  database:
     command:
-      - --ssl-ca=/etc/pki/CA/cacert-${DOMAIN_NAME?err}.pem
-      - --ssl-cert=/etc/pki/tls/certs/servercert-${DOMAIN_NAME?err}.pem
-      - --ssl-key=/etc/pki/tls/private/serverkey-${DOMAIN_NAME?err}.pem
+      - --ssl-ca=/etc/pki/CA/cacert-database.pem
+      - --ssl-cert=/etc/pki/tls/certs/servercert-database.pem
+      - --ssl-key=/etc/pki/tls/private/serverkey-database.pem
       # - --mysql-native-password=ON
       # - --default-authentication-plugin=mysql_native_password
     depends_on:
       - ssl_certificate
     entrypoint: setup-certificate.sh
     environment:
-      DOMAIN_NAME: ${DOMAIN_NAME?err}
+      DOMAIN_NAME: database
       MYSQL_ROOT_PASSWORD: examplepass
     image: mysql:${MYSQL_VERSION:?err}
     volumes:
@@ -35,12 +35,10 @@ services:
       - -c
       - "phpunit --version && phpcs --version"
     depends_on:
-      - database.${DOMAIN_NAME?err}
+      - database
       - ssl_certificate
     environment:
-      DATABASE_HOST: database.${DOMAIN_NAME?err}
       DATABASE_PASSWORD: examplepass
-      DOMAIN_NAME: ${DOMAIN_NAME?err}
     volumes:
       # To enable SSL for MySQL serving.
       - pki:/etc/pki

--- a/database_entrypoint/setup-certificate.sh
+++ b/database_entrypoint/setup-certificate.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
+set -eu
+
 SERVERCERT="/etc/pki/tls/certs/servercert-${DOMAIN_NAME}.pem"
 SERVERKEY="/etc/pki/tls/private/serverkey-${DOMAIN_NAME}.pem"
 while :; do

--- a/shell-scripts-to-copy/entrypoint.sh
+++ b/shell-scripts-to-copy/entrypoint.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -eu
 
+DOMAIN_NAME=${DOMAIN_NAME-database}
+DATABASE_NAME=${DATABASE_NAME-wordpress}
+DATABASE_USER=${DATABASE_USER-root}
+DATABASE_PASSWORD=${DATABASE_PASSWORD}
+DATABASE_HOST=${DATABASE_HOST-database}
+DATABASE_PORT=${DATABASE_PORT-3306}
+WORDPRESS_VERSION=${WORDPRESS_VERSION-latest}
+
 SERVERCERT="/etc/pki/tls/certs/servercert-${DOMAIN_NAME}.pem"
 SERVERKEY="/etc/pki/tls/private/serverkey-${DOMAIN_NAME}.pem"
 while :; do
@@ -12,13 +20,6 @@ done
 
 cp -p /etc/pki/CA/cacert-${DOMAIN_NAME}.pem /usr/local/share/ca-certificates/cacert-${DOMAIN_NAME}.crt
 update-ca-certificates
-
-DATABASE_NAME=${DATABASE_NAME-wordpress}
-DATABASE_USER=${DATABASE_USER-root}
-DATABASE_PASSWORD=${DATABASE_PASSWORD}
-DATABASE_HOST=${DATABASE_HOST-database}
-DATABASE_PORT=${DATABASE_PORT-3306}
-WORDPRESS_VERSION=${WORDPRESS_VERSION-latest}
 
 # Sometimes, timeout occurred when set 45 seconds for MySQL 8
 wait-for-it --timeout=90 "${DATABASE_HOST}:${DATABASE_PORT}" -- install-wp-tests "${DATABASE_NAME}" "${DATABASE_USER}" "${DATABASE_PASSWORD}" "${DATABASE_HOST}:${DATABASE_PORT}" "${WORDPRESS_VERSION}"


### PR DESCRIPTION
This pull request updates the test and deployment configuration to simplify service naming and environment variable management, and to improve compatibility with updated SSL certificate tooling. The changes remove unnecessary domain indirection, standardize environment variables, and upgrade the SSL certificate image for better root domain support.

**Configuration and Environment Variable Simplification:**

* Removed the `DOMAIN_NAME` environment variable and related comments from the GitHub Actions workflow files (`.github/workflows/deploy.yml`, `.github/workflows/test.yml`), as the new setup no longer requires domain indirection. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L30-L31) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L34-L35)
* Standardized the use of `database` as the service and host name throughout `compose.test.yml`, eliminating references to `${DOMAIN_NAME}` and simplifying service dependencies and environment variables. [[1]](diffhunk://#diff-70c70fc1bc572d534185ba1c7dda30402d5b56600677a181eeae3511383320c7L7-R23) [[2]](diffhunk://#diff-70c70fc1bc572d534185ba1c7dda30402d5b56600677a181eeae3511383320c7L38-L43)

**SSL Certificate and Service Improvements:**

* Upgraded the `ssl_certificate` service to use `futureys/ssl-certificate:2.1.1` with `SUPPORT_ROOT_DOMAIN: true`, allowing direct use of the root domain and simplifying certificate management.
* Updated the `database` service to use the new certificate file names and direct references to `database` as the domain.

**Script Enhancements:**

* Added `set -eu` to `database_entrypoint/setup-certificate.sh` for stricter error handling.
* Refactored `shell-scripts-to-copy/entrypoint.sh` to set default values for environment variables at the top of the script, improving maintainability and clarity.
* Moved environment variable defaults to the top of `entrypoint.sh` and removed redundant assignments after certificate installation.